### PR TITLE
Feature/bug fix and dependency maintenance

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -9,7 +9,7 @@
       ]
     },
     "dpi": {
-      "version": "2022.11.10.59",
+      "version": "2023.2.7.62",
       "commands": [
         "dpi"
       ]

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-      "version": "7.0.103",
+      "version": "7.0.203",
       "rollForward": "latestMinor",
       "allowPrerelease": false
   }

--- a/src/BRI.Tests/BRI.Tests.csproj
+++ b/src/BRI.Tests/BRI.Tests.csproj
@@ -30,15 +30,21 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
-    <PackageReference Include="coverlet.collector" Version="3.1.2" />
-    <PackageReference Include="Verify.NUnit" Version="19.6.0" />
-    <PackageReference Include="Verify.Http" Version="4.1.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.6.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Verify.NUnit" Version="19.12.3" />
+    <PackageReference Include="Verify.Http" Version="4.2.1" />
     <PackageReference Include="Cake.Testing" Version="3.0.0" />
-    <PackageReference Include="NSubstitute" Version="4.4.0" />
+    <PackageReference Include="NSubstitute" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BRI.Tests/Unit/Services/Acr/Repository/BlobServiceTests.GetModule.verified.txt
+++ b/src/BRI.Tests/Unit/Services/Acr/Repository/BlobServiceTests.GetModule.verified.txt
@@ -112,26 +112,36 @@
   Outputs: {
     animal: {
       Type: object,
-      Value: [parameters('animal')]
+      Value: {
+        ValueKind: String
+      }
     },
     base64Encoded: {
       Type: string,
-      Value: [variables('base64Encoded')]
+      Value: {
+        ValueKind: String
+      }
     },
     eatsFruit: {
       Type: bool,
-      Value: [variables('eatsFruit')],
+      Value: {
+        ValueKind: String
+      },
       Metadata: {
         Description: Flag if animal eats fruit.
       }
     },
     parent: {
       Type: string,
-      Value: [parameters('parent')]
+      Value: {
+        ValueKind: String
+      }
     },
     uniqueName: {
       Type: string,
-      Value: [variables('uniqueName')],
+      Value: {
+        ValueKind: String
+      },
       Metadata: {
         Description: Unique name of animal
       }

--- a/src/BRI/BRI.csproj
+++ b/src/BRI/BRI.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
-    <PackageReference Include="Cake.Bridge.DependencyInjection" Version="0.13.0" />
+    <PackageReference Include="Cake.Bridge.DependencyInjection" Version="0.14.0" />
     <PackageReference Include="Cake.Common" Version="3.0.0" />
     <PackageReference Include="Spectre.Console.Cli.Extensions.DependencyInjection" Version="0.1.0" />
     <PackageReference Include="Spectre.Console" Version="0.45.0" />

--- a/src/BRI/BRI.csproj
+++ b/src/BRI/BRI.csproj
@@ -43,8 +43,8 @@
     <PackageReference Include="Cake.Bridge.DependencyInjection" Version="0.14.0" />
     <PackageReference Include="Cake.Common" Version="3.0.0" />
     <PackageReference Include="Spectre.Console.Cli.Extensions.DependencyInjection" Version="0.1.0" />
-    <PackageReference Include="Spectre.Console" Version="0.45.0" />
-    <PackageReference Include="Spectre.Console.Cli" Version="0.45.0" />
+    <PackageReference Include="Spectre.Console" Version="0.46.0" />
+    <PackageReference Include="Spectre.Console.Cli" Version="0.46.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/BRI/BRI.csproj
+++ b/src/BRI/BRI.csproj
@@ -34,7 +34,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.8.0" />
+    <PackageReference Include="Azure.Identity" Version="1.8.2" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />

--- a/src/BRI/Models/Acr/Repository/Module/Output.cs
+++ b/src/BRI/Models/Acr/Repository/Module/Output.cs
@@ -4,7 +4,7 @@ public record Output(
         [property: JsonPropertyName("type")]
         string Type,
         [property: JsonPropertyName("value")]
-        string Value,
+        JsonElement Value,
         [property: JsonPropertyName("metadata")]
         Metadata Metadata
     );

--- a/src/BRI/Program.cs
+++ b/src/BRI/Program.cs
@@ -1,12 +1,7 @@
 ﻿using BRI.Commands;
-using BRI.Services;
 using Microsoft.Extensions.Configuration.Memory;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
 using Spectre.Console.Cli.Extensions.DependencyInjection;
-using Spectre.Console.Cli;
-using BRI.Services.Acr;
-using BRI.Services.Acr.Repository;
 using Azure.Core;
 using Azure.Identity;
 


### PR DESCRIPTION
## Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8b3f000</samp>

This pull request updates the project to use the latest versions of the .NET SDK and some packages, and improves the functionality and performance of the `inventory` command. It also changes the `Output` model class to use `JsonElement` instead of `string` for the `Value` property, and updates the tests and documentation accordingly. Additionally, it removes some unused code and fixes some minor issues.

## Explanation of changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8b3f000</samp>

*  Updated the .NET SDK version to `7.0.203` for the latest features and fixes ([link](https://github.com/devlead/bri/pull/1/files?diff=unified&w=0#diff-8df3cd354bc584349d04ad5675b33c042d8b99b741b8b95af394c55e0f5001bfL3-R3))
*  Updated the `dpi` tool version to `2023.2.7.62` for generating documentation for bicep modules ([link](https://github.com/devlead/bri/pull/1/files?diff=unified&w=0#diff-7afd3bcf0d0c06d6f87c451ef06b321beef770ece4299b3230bb280470ada2f6L12-R12))
*  Changed the type of the `Value` property in the `Output` model class from `string` to `JsonElement` to handle different types of values returned by bicep modules ([link](https://github.com/devlead/bri/pull/1/files?diff=unified&w=0#diff-1c7b4bacb677fbca0366be33d4349ef8417cd9eb3de84679b713cd155c590aadL7-R7))
*  Updated the expected output of the `GetModule` test in `BlobServiceTests.GetModule.verified.txt` to reflect the change in the `Output` model class ([link](https://github.com/devlead/bri/pull/1/files?diff=unified&w=0#diff-cdbd1f88b908c78814e32927ec63c40558e872f098ed93da5bc2d97d65265b5eL115-R129), [link](https://github.com/devlead/bri/pull/1/files?diff=unified&w=0#diff-cdbd1f88b908c78814e32927ec63c40558e872f098ed93da5bc2d97d65265b5eL130-R144))
*  Improved the performance and scalability of the `inventory` command by using parallel asynchronous loops in the `ExecuteAsync` method in `InventoryCommand.cs` ([link](https://github.com/devlead/bri/pull/1/files?diff=unified&w=0#diff-832dd3d57223da566cf6e77b1858886b0a70442d13f1247af73e27d4e7a71334L28-R65))
*  Updated the versions of several NuGet packages for the latest features and fixes in `BRI.csproj` and `BRI.Tests.csproj` ([link](https://github.com/devlead/bri/pull/1/files?diff=unified&w=0#diff-c7be788d513ec0ebc1ecb7f828bae92e5d3f6f6368b500f77e3e3bba62e3e475L33-R47), [link](https://github.com/devlead/bri/pull/1/files?diff=unified&w=0#diff-02c2c9d97363fcc11762d360a191fad790f03b80af7ab8a800b6a9dd955661f4L37-R37), [link](https://github.com/devlead/bri/pull/1/files?diff=unified&w=0#diff-02c2c9d97363fcc11762d360a191fad790f03b80af7ab8a800b6a9dd955661f4L43-R47))
*  Added the `IncludeAssets` and `PrivateAssets` properties to the `NUnit.Analyzers` and `coverlet.collector` packages in `BRI.Tests.csproj` to prevent them from being exposed or published ([link](https://github.com/devlead/bri/pull/1/files?diff=unified&w=0#diff-c7be788d513ec0ebc1ecb7f828bae92e5d3f6f6368b500f77e3e3bba62e3e475L33-R47))
*  Removed the unused `using` directives from `Program.cs` to improve the readability and maintainability of the code ([link](https://github.com/devlead/bri/pull/1/files?diff=unified&w=0#diff-5f839df9dd9f03bcd6223e383bec7e3e8238b714c9ee7d2fccebc5454700fde7L2-R4))
