### PR TITLE
chore(deps): update NuGet packages to latest versions

### DIFF
--- a/src/BRI.TestWeb/BRI.TestWeb.csproj
+++ b/src/BRI.TestWeb/BRI.TestWeb.csproj
@@ -12,15 +12,15 @@
   <ItemGroup>
     <PackageReference Include="Devlead.Statiq" Version="2025.9.10.150" />
     <PackageReference Include="Statiq.Web" Version="1.0.0-beta.60" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.1" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.2" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.15.0" />
-    <PackageReference Include="System.Drawing.Common" Version="10.0.1" />
+    <PackageReference Include="System.Drawing.Common" Version="10.0.2" />
     <PackageReference Include="System.Data.SqlClient" Version="4.9.0" />
     <PackageReference Include="Azure.Identity" Version="1.17.1" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="System.Formats.Asn1" Version="10.0.1" />
-    <PackageReference Include="System.DirectoryServices.Protocols" Version="10.0.1" />
+    <PackageReference Include="System.Formats.Asn1" Version="10.0.2" />
+    <PackageReference Include="System.DirectoryServices.Protocols" Version="10.0.2" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
   </ItemGroup>
 

--- a/src/BRI.Tests/BRI.Tests.csproj
+++ b/src/BRI.Tests/BRI.Tests.csproj
@@ -43,7 +43,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Verify.NUnit" Version="31.9.4" />
-    <PackageReference Include="Devlead.Testing.MockHttp" Version="2025.12.16.528" />
+    <PackageReference Include="Devlead.Testing.MockHttp" Version="2026.1.14.568" />
     <PackageReference Include="Cake.Testing" Version="6.0.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
   </ItemGroup>

--- a/src/BRI/BRI.csproj
+++ b/src/BRI/BRI.csproj
@@ -38,11 +38,11 @@
     <PackageReference Include="Azure.Identity" Version="1.17.1" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1 " Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.11" Condition="'$(TargetFramework)' == 'net9.0'" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.1" Condition="'$(TargetFramework)' == 'net10.0'" />
-    <PackageReference Include="Cake.Bridge.DependencyInjection" Version="2025.12.17.441" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.12" Condition="'$(TargetFramework)' == 'net9.0'" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.2" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageReference Include="Cake.Bridge.DependencyInjection" Version="2026.1.14.460" />
     <PackageReference Include="Cake.Common" Version="6.0.0" />
-    <PackageReference Include="Devlead.Console" Version="2025.12.17.530" />
+    <PackageReference Include="Devlead.Console" Version="2026.1.14.558" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Update System.* packages from 10.0.1 to 10.0.2 in BRI.TestWeb
  - System.Security.Cryptography.Xml
  - System.Drawing.Common
  - System.Formats.Asn1
  - System.DirectoryServices.Protocols
- Update Microsoft.Extensions.Http to 9.0.12 and 10.0.2 in BRI
- Update Devlead packages to 2026.1.14 versions
  - Devlead.Console: 2025.12.17.530 → 2026.1.14.558
  - Devlead.Testing.MockHttp: 2025.12.16.528 → 2026.1.14.568
- Update Cake.Bridge.DependencyInjection to 2026.1.14.460