### PR TITLE
fix: align Spectre command API and resolve ClientRuntime constraint

### DIFF
--- a/src/BRI.TestWeb/BRI.TestWeb.csproj
+++ b/src/BRI.TestWeb/BRI.TestWeb.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="System.Formats.Asn1" Version="10.0.8" />
     <PackageReference Include="System.DirectoryServices.Protocols" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="3.0.3" />
+    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BRI.Tests/Unit/Commands/InventoryCommandTests.cs
+++ b/src/BRI.Tests/Unit/Commands/InventoryCommandTests.cs
@@ -2,6 +2,7 @@
 using BRI.Commands.Settings;
 using Cake.Core;
 using Spectre.Console.Cli;
+using System.Runtime;
 
 namespace BRI.Tests.Unit.Commands;
 
@@ -40,7 +41,7 @@ public class InventoryCommandTests
                                 .AddSingleton<InventoryCommand>()
             );
 
-        var command = new InventoryCommand(
+        ICommand<InventorySettings> command = new InventoryCommand(
             cakeContext,
             logger,
             catalogService,

--- a/src/BRI/BRI.csproj
+++ b/src/BRI/BRI.csproj
@@ -39,10 +39,10 @@
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1 " Condition="'$(TargetFramework)' == 'net8.0'" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.16" Condition="'$(TargetFramework)' == 'net9.0'" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.8" Condition="'$(TargetFramework)' == 'net10.0'" />
     <PackageReference Include="Cake.Bridge.DependencyInjection" Version="2026.5.18.616" />
     <PackageReference Include="Cake.Common" Version="6.1.0" />
-    <PackageReference Include="Devlead.Console" Version="2026.2.11.575" />
+    <PackageReference Include="Devlead.Console" Version="2026.5.15.709" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BRI/Commands/InventoryCommand.cs
+++ b/src/BRI/Commands/InventoryCommand.cs
@@ -10,7 +10,7 @@ public class InventoryCommand : AsyncCommand<InventorySettings>
     private RepositoryService RepositoryService { get; }
     private BicepModuleMarkdownService BicepModuleMarkdownService { get; }
 
-    public override async Task<int> ExecuteAsync(CommandContext context, InventorySettings settings, CancellationToken cancellationToken)
+    protected override async Task<int> ExecuteAsync(CommandContext context, InventorySettings settings, CancellationToken cancellationToken)
     {
         var sw = System.Diagnostics.Stopwatch.StartNew();
         Logger.LogInformation("AcrLoginServer: {AcrLoginServer}", settings.AcrLoginServer);


### PR DESCRIPTION
- InventoryCommand: make ExecuteAsync protected override (Spectre/Devlead.Console API)
- InventoryCommandTests: use ICommand<InventorySettings> for command variable
- BRI.TestWeb: pin Microsoft.Rest.ClientRuntime to 2.3.24 (< 3.0 required by transitive Microsoft.Azure.Search via Statiq)
- BRI: bump Microsoft.Extensions.Http 10.0.8 (net10.0), Devlead.Console